### PR TITLE
Make warning due to unknown tag ID more verbose

### DIFF
--- a/applications/camera_calibration/src/camera_calibration/feature_detection/feature_detector_tagged_pattern.cc
+++ b/applications/camera_calibration/src/camera_calibration/feature_detection/feature_detector_tagged_pattern.cc
@@ -818,7 +818,7 @@ void FeatureDetectorTaggedPattern::PredictFeaturesNextToAprilTags(
       }
     }
     if (pattern_array_index < 0) {
-      LOG(WARNING) << "Detected an AprilTag that does not belong to a known pattern.";
+      LOG(WARNING) << "Detected AprilTag " << tag_detection->id << " which does not belong to a known pattern.";
       continue;
     }
     


### PR DESCRIPTION
I mixed up my targets and got confused so I changed the code to tell me which target could not be assigned to a specified target.