### PR TITLE
Add export functionality for 3D points and a visualization tool

### DIFF
--- a/applications/camera_calibration/CMakeLists.txt
+++ b/applications/camera_calibration/CMakeLists.txt
@@ -220,7 +220,25 @@ if (CMAKE_CUDA_COMPILER)
   set_target_properties(camera_calibration PROPERTIES
     POSITION_INDEPENDENT_CODE ON
   )
-  
+
+  # Tool for generating visualizations from reprojection error data provided by other software
+  add_executable(report_from_data
+    src/camera_calibration/report_from_data.cc
+  )
+  target_include_directories(report_from_data PRIVATE
+    src
+    third_party/yaml-cpp-0.6.0/include
+  )
+  target_link_libraries(report_from_data PRIVATE
+    camera_calibration_baselib
+    ${Boost_LIBRARIES}
+    yaml-cpp2
+    libvis_external_io
+  )
+  set_target_properties(report_from_data PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+  )
+
   
   # Resource files for unit tests
   ADD_CUSTOM_TARGET(camera_calibration_test_resources ALL

--- a/applications/camera_calibration/src/camera_calibration/calibration.cc
+++ b/applications/camera_calibration/src/camera_calibration/calibration.cc
@@ -242,6 +242,7 @@ void RunBundleAdjustment(
       // Save the optimization state
       if (state_output_path) {
         SaveBAState(state_output_path, *state);
+        SaveDatasetAndState(state_output_path, *dataset, *state);
       }
       
       // Beautify all camera orientations
@@ -1115,7 +1116,11 @@ bool Calibrate(
     }
     
     if (dataset_output_path) {
-      SaveDataset(dataset_output_path, *dataset);
+      SaveDatasetAndState(dataset_output_path, *dataset, *state);
+      LOG(INFO) << "Saved dataset at " << dataset_output_path;
+    }
+    else {
+      LOG(INFO) << "Didn't save dataset";
     }
   }
   
@@ -1322,10 +1327,10 @@ void CalibrateBatch(
   
   // Save the resulting calibration.
   if (!state_output_directory.empty()) {
-    SaveBAState(state_output_directory.c_str(), calibration);
+    SaveDatasetAndState(state_output_directory.c_str(), dataset, calibration);
   }
   if (!pruned_dataset_output_path.empty()) {
-    SaveDataset(pruned_dataset_output_path.c_str(), dataset);
+    SaveDatasetAndState(pruned_dataset_output_path.c_str(), dataset, calibration);
   }
   
   // Create the calibration error report.

--- a/applications/camera_calibration/src/camera_calibration/calibration_report.h
+++ b/applications/camera_calibration/src/camera_calibration/calibration_report.h
@@ -48,11 +48,20 @@ int CreateCalibrationReport(
     const Dataset& dataset,
     const BAState& calibration,
     const string& report_base_path);
+
 bool CreateCalibrationReportForCamera(
     const char* base_path,
     int camera_index,
     const Dataset& dataset,
     const BAState& calibration);
+
+bool CreateCalibrationReportForData(
+    const char* base_path,
+    int camera_index,
+    const int width,
+    const int height,
+    vector<Vec2d> const& reprojection_errors,
+    vector<Vec2f> const& features);
 
 void CreateReprojectionErrorHistogram(
     int camera_index,

--- a/applications/camera_calibration/src/camera_calibration/io/calibration_io.h
+++ b/applications/camera_calibration/src/camera_calibration/io/calibration_io.h
@@ -50,6 +50,9 @@ bool SaveDataset(
     const char* path,
     const Dataset& dataset);
 
+bool SaveDatasetAndState(const char* path, const Dataset& dataset, const BAState& state);
+
+
 /// Tries to load a dataset from the given path. Returns true if successful.
 bool LoadDataset(
     const char* path,

--- a/applications/camera_calibration/src/camera_calibration/main.cc
+++ b/applications/camera_calibration/src/camera_calibration/main.cc
@@ -555,6 +555,7 @@ int LIBVIS_QT_MAIN(int argc, char** argv) {
           dataset_yaml_file << "- camera: \"" << inputs[i]->display_text.toStdString() << "\"" << endl;
           dataset_yaml_file << "  path: \"" << image_record_directories[i].dirName().toStdString() << "\"" << endl;
         }
+        LOG(INFO) << "Wrote dataset YAML file at: " << dataset_yaml_path;
       } else {
         LOG(ERROR) << "Failed to write dataset YAML file at: " << dataset_yaml_path;
       }
@@ -591,7 +592,9 @@ int LIBVIS_QT_MAIN(int argc, char** argv) {
     if (settings_window.SaveDatasetOnExit() || settings_window.show_pattern_clicked()) {
       QDir record_directory = QDir(settings_window.RecordDirectory());
       record_directory.mkpath(".");
-      SaveDataset(record_directory.absoluteFilePath("features.bin").toStdString().c_str(), dataset);
+      std::string const dataset_path = record_directory.absoluteFilePath("features.bin").toStdString();
+      SaveDataset(dataset_path.c_str(), dataset);
+      LOG(INFO) << "Saved dataset at " << dataset_path;
     }
     
     delete main_window;

--- a/applications/camera_calibration/src/camera_calibration/report_from_data.cc
+++ b/applications/camera_calibration/src/camera_calibration/report_from_data.cc
@@ -1,0 +1,128 @@
+// Copyright 2019 ETH Zürich, Thomas Schöps
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#undef NDEBUG
+#include <cassert>
+
+#include <algorithm>
+#include <iomanip>
+#include <iostream>
+#include <unordered_map>
+
+#include <boost/filesystem.hpp>
+#include <Eigen/Geometry>
+#include <libvis/camera.h>
+#include <libvis/command_line_parser.h>
+#include <libvis/eigen.h>
+#include <libvis/external_io/colmap_model.h>
+#include <libvis/geometry.h>
+#include <libvis/image_display.h>
+#include <libvis/libvis.h>
+#include <libvis/point_cloud.h>
+#include <QSharedPointer>
+#include <QtWidgets>
+
+#include <rapidjson/document.h>
+#include <rapidjson/istreamwrapper.h>
+
+#include "camera_calibration/bundle_adjustment/ba_state.h"
+#include "camera_calibration/bundle_adjustment/joint_optimization.h"
+#include "camera_calibration/calibration.h"
+#include "camera_calibration/calibration_report.h"
+#include "camera_calibration/feature_detection/feature_detector_tagged_pattern.h"
+#include "camera_calibration/fitting_report.h"
+#include "camera_calibration/io/calibration_io.h"
+#include "camera_calibration/image_input/image_input_realsense.h"
+#include "camera_calibration/image_input/image_input_v4l2.h"
+#include "camera_calibration/models/all_models.h"
+#include "camera_calibration/tools/tools.h"
+#include "camera_calibration/ui/calibration_window.h"
+#include "camera_calibration/ui/live_image_consumer.h"
+#include "camera_calibration/ui/main_window.h"
+#include "camera_calibration/ui/pattern_display.h"
+#include "camera_calibration/ui/settings_window.h"
+#include "camera_calibration/util.h"
+
+using namespace vis;
+
+
+Q_DECLARE_METATYPE(QSharedPointer<Image<Vec3u8>>)
+
+namespace rs = rapidjson;
+
+void runReport(std::string const& input_filename) {
+    ifstream ifs(input_filename);
+    rapidjson::IStreamWrapper isw(ifs);
+
+    rapidjson::Document d;
+    d.ParseStream(isw);
+
+    int const width = d["width"].GetInt();
+    int const height = d["height"].GetInt();
+
+    vector<Vec2d> errors;
+    vector<Vec2f> features;
+
+    assert(d["errors"].IsArray());
+    assert(d["features"].IsArray());
+
+    rs::Value errors_j = d["errors"].GetArray();
+
+    rs::Value features_j = d["features"].GetArray();
+
+    LOG(INFO) << "File " << input_filename << " has width/height " << width << ", " << height << " and " << errors_j.Size() << " errors";
+
+    assert(errors_j.Size() > 0);
+    assert(errors_j.Size() == features_j.Size());
+
+    for (size_t ii = 0; ii < errors_j.Size(); ++ii) {
+        assert(errors_j[ii].IsArray());
+        assert(features_j[ii].IsArray());
+        assert(errors_j[ii].Size() == 2);
+        assert(features_j[ii].Size() == 2);
+
+        errors.push_back(Vec2d(errors_j[ii][0].GetDouble(), errors_j[ii][1].GetDouble()));
+        features.push_back(Vec2f(features_j[ii][0].GetDouble(), features_j[ii][1].GetDouble()));
+    }
+
+    LOG(INFO) << "Read all errors and features";
+
+    CreateCalibrationReportForData((input_filename + "_report").c_str(), 0, width, height, errors, features);
+    LOG(INFO) << "Finished writing report";
+}
+
+int LIBVIS_QT_MAIN(int argc, char** argv) {
+  qRegisterMetaType<QSharedPointer<Image<Vec3u8>>>();
+  srand(0);
+
+  for (int ii = 1; ii < argc; ++ii) {
+    runReport(argv[ii]);
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/applications/camera_calibration/src/camera_calibration/tools/bundle_adjustment.cc
+++ b/applications/camera_calibration/src/camera_calibration/tools/bundle_adjustment.cc
@@ -203,7 +203,8 @@ int BundleAdjustment(const string& state_directory, const string& model_input_di
     
     // Save the optimization state after each iteration
     SaveBAState(model_output_directory.c_str(), state);
-    
+    SaveDatasetAndState(model_output_directory.c_str(), dataset, state);
+
     // Save the final cost
     std::ofstream cost_stream((boost::filesystem::path(model_output_directory) / "cost.txt").string().c_str(), std::ios::out);
     if (cost_stream) {

--- a/libvis/src/libvis/image.cc
+++ b/libvis/src/libvis/image.cc
@@ -26,6 +26,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#include <fstream>
 
 #include "libvis/image.h"
 

--- a/libvis/src/libvis/image.h
+++ b/libvis/src/libvis/image.h
@@ -35,6 +35,7 @@
   #include <opencv2/core/core.hpp>
 #endif
 
+#include <fstream>
 #include "libvis/logging.h"
 
 #include "libvis/eigen.h"
@@ -1768,6 +1769,10 @@ template<>
 bool Image<Vec3u8>::Write(const string& image_file_name) const;
 template<>
 bool Image<Vec4u8>::Write(const string& image_file_name) const;
+template<>
+bool Image<float>::Write(const string& image_file_name) const;
+template<>
+bool Image<Vec2f>::Write(const string& image_file_name) const;
 template<>
 bool Image<u8>::Read(const string& image_file_name);
 template<>


### PR DESCRIPTION
I implemented #43 (first commit).
I think the visualization of error directions and magnitude is great and I wanted to use it for visualizing results from other calibration methods. I also wanted to use different color scales for the visualization so I added methods to export Image<float> to text files I can process with gnuplot, and Image<Vec2f> to optical flow files in the Middlebury format (https://vision.middlebury.edu/flow/data/).